### PR TITLE
Add base network interface to configuration

### DIFF
--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -33,7 +33,10 @@ if (!isConnect()) {
                     <?php
                         $interfaces = network::getInterfaces();
                         foreach ($interfaces as $interface) {
-                            echo '<option value="'.$interface.'">'. $interface. '</option>';
+                            $baseInterface = substr($interface, 0, strrpos($interface, '@'));
+                            if ($baseInterface && $baseInterface != $interface)
+                                echo '<option value="' . $baseInterface . '">' . $baseInterface . '</option>';
+                            echo '<option value="' . $interface . '">' . $interface . '</option>';
                         }
                     ?>
                 </select>


### PR DESCRIPTION
In my case, my networks contains iflink or ifindex (ie: eth1@if2)
pcap library cannot link to this network but can link to "eth1".
So, I add base interface "eth1" on configuration form.